### PR TITLE
Nuxt Config for Sass Loader changed

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -25,7 +25,10 @@ module.exports = {
   },
    modules: [
   // provide path to the file with resources
-  ['nuxt-sass-resources-loader', './assets/scss/main.scss']
+  'nuxt-sass-resources-loader'
+  ],
+  sassResources:[
+     './assets/scss/main.scss'
   ],
   ...routerBase,
   /*


### PR DESCRIPTION
Nuxt Config file changed from 
` modules: [
  // provide path to the file with resources
  ['nuxt-sass-resources-loader', './assets/scss/main.scss']
  ]` to 
` modules: [
  // provide path to the file with resources
  'nuxt-sass-resources-loader'
  ],
  sassResources:[
     './assets/scss/main.scss'
  ]`
